### PR TITLE
add 1.5 version tag

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -7,6 +7,7 @@
 		<li>1.2</li>
 		<li>1.3</li>
 		<li>1.4</li>
+		<li>1.5</li>
 	</supportedVersions>
 	<author>bradson,harkon</author>
 	<modDependencies>


### PR DESCRIPTION
reportedly works still fine in v1.5